### PR TITLE
Fix white submenu text.

### DIFF
--- a/src/Classic.Avalonia.Theme/Styles/MenuItem.axaml
+++ b/src/Classic.Avalonia.Theme/Styles/MenuItem.axaml
@@ -121,7 +121,6 @@
     </Style>
 
     <Style Selector="^:selected">
-      <Setter Property="Foreground" Value="{DynamicResource {x:Static classic:SystemColors.HighlightTextBrushKey}}" />
       <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
         <Setter Property="Foreground" Value="{DynamicResource {x:Static classic:SystemColors.HighlightTextBrushKey}}" />
       </Style>


### PR DESCRIPTION
Noticed a bug with submenu text always displaying white. e.g. opening the File -> New would show the "Blank Page" and "From clipboard" text as white. I've removed the line that was causing this and now it displays correctly. I've also tested it with nested submenus.